### PR TITLE
fix(eslint-config): oxlint will exit with non-zero if all linting files are not supported

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -8,7 +8,6 @@
       "dom.iterable",
       "esnext"
     ],
-    "baseUrl": ".",
     "module": "esnext",
     "moduleResolution": "bundler",
     "paths": {
@@ -25,6 +24,8 @@
     "noEmit": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    // https://stackoverflow.com/a/79878514
+    "noUncheckedSideEffectImports": false,
     "isolatedModules": true,
     "skipLibCheck": true,
     "plugins": [

--- a/packages/eslint-config/src/moeru-lint.js
+++ b/packages/eslint-config/src/moeru-lint.js
@@ -63,7 +63,12 @@ else {
   const fixSuggestions = values['fix-suggestions'] ? '--fix-suggestions' : ''
   const cache = values['no-cache'] ? '' : '--cache'
 
-  const oxcArgs = [fix, fixDangerously, fixSuggestions, ...paths].filter(v => v.length > 0)
+  // NOTICE: since oxlint cannot handle unsupported file paths, if
+  // the committing files are all unsupported file paths (updating package.json, or flushing
+  // i18n, lock files), oxlint will exit with a non-zero exit code before eslint is executed.
+  //
+  // To avoid this, we add the `--no-error-on-unmatched-pattern` flag to oxlint.
+  const oxcArgs = ['--no-error-on-unmatched-pattern', fix, fixDangerously, fixSuggestions, ...paths].filter(v => v.length > 0)
   const eslintArgs = [fix, cache, ...paths].filter(v => v.length > 0)
   const eslintFlags = values.flag?.join(',')
 

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,6 +1,9 @@
 {
   "extends": "@moeru/tsconfig",
   "compilerOptions": {
+    "types": [
+      "node"
+    ],
     "allowJs": true,
     "checkJs": true
   },


### PR DESCRIPTION
```shell
  √ Preparing nano-staged
  × Running tasks for staged files
    × * - 48 files
      × moeru-lint --fix
  √ Restoring to original state because of errors
  Finished in 11ms on 0 files with 93 rules using 18 threads.
```